### PR TITLE
Add create_account helper to Actor.

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -2,6 +2,7 @@ use crate::errors::Error;
 use crate::sandbox::Sandbox;
 use serde_json;
 use solana_sdk::{
+    instruction::Instruction,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
@@ -97,5 +98,24 @@ impl<'a> Actor<'a> {
                 std::io::ErrorKind::InvalidInput,
             )))
         }
+    }
+
+    /// Returns an instruction to create an account at the given address with
+    /// the given size and owner. Funds the account so that it is rent-exempt.
+    pub fn create_account(
+        &self,
+        target: &Pubkey,
+        target_bytes: usize,
+        target_owner: &Pubkey,
+    ) -> Result<Instruction, Error> {
+        Ok(solana_sdk::system_instruction::create_account(
+            self.pubkey(),
+            target,
+            self.sandbox
+                .client()
+                .get_minimum_balance_for_rent_exemption(target_bytes)?,
+            target_bytes as u64,
+            target_owner,
+        ))
     }
 }

--- a/src/serum.rs
+++ b/src/serum.rs
@@ -141,15 +141,7 @@ impl<'a> Market<'a> {
 
         let mut instructions = Vec::new();
         for (pubkey, len) in sized_accounts.iter() {
-            instructions.push(solana_sdk::system_instruction::create_account(
-                actor.pubkey(),
-                pubkey,
-                sandbox
-                    .client()
-                    .get_minimum_balance_for_rent_exemption(*len)?,
-                *len as u64,
-                serum,
-            ));
+            instructions.push(actor.create_account(pubkey, *len, serum)?);
         }
 
         instructions.push(serum_dex::instruction::initialize_market(

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 use crate::actor::Actor;
 use crate::errors::Error;
 use crate::sandbox::Sandbox;
-use solana_program::{program_pack::Pack, system_instruction};
+use solana_program::program_pack::Pack;
 use solana_sdk::{pubkey::Pubkey, transaction::Transaction};
 use spl_token::{self, instruction as spl_instruction, state as spl_state};
 
@@ -37,18 +37,8 @@ impl<'a> Mint<'a> {
             None => authority,
         };
 
-        let mint_size = spl_state::Mint::LEN;
-        let mint_rent = sandbox
-            .client()
-            .get_minimum_balance_for_rent_exemption(mint_size)?;
-        let create_account = system_instruction::create_account(
-            actor.pubkey(),
-            mint.pubkey(),
-            mint_rent,
-            mint_size as u64,
-            &spl_token::id(),
-        );
-
+        let create_account =
+            actor.create_account(mint.pubkey(), spl_state::Mint::LEN, &spl_token::id())?;
         let initialize_mint = spl_instruction::initialize_mint(
             &spl_token::id(),
             mint.pubkey(),
@@ -148,18 +138,8 @@ impl<'a> TokenAccount<'a> {
             None => actor.pubkey(),
         };
 
-        let account_size = spl_state::Account::LEN;
-        let account_rent = sandbox
-            .client()
-            .get_minimum_balance_for_rent_exemption(account_size)?;
-        let create_account = system_instruction::create_account(
-            actor.pubkey(),
-            account.pubkey(),
-            account_rent,
-            account_size as u64,
-            &spl_token::id(),
-        );
-
+        let create_account =
+            actor.create_account(account.pubkey(), spl_state::Account::LEN, &spl_token::id())?;
         let initialize_account = spl_instruction::initialize_account(
             &spl_token::id(),
             account.pubkey(),


### PR DESCRIPTION
Reduces boilerplate around system program account creation with rent
exemption. Replaced manual account creation everywhere with this helper.