### PR TITLE
Attach crank functionality to Market & minimize boilerplate

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,7 +1,7 @@
-use crate::errors::Error;
+use crate::errors::{Error, Result};
 use crate::sandbox::Sandbox;
-use serde_json;
 use solana_sdk::{
+    account::Account,
     instruction::Instruction,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
@@ -18,20 +18,24 @@ pub struct Actor<'a> {
 
 impl<'a> Actor<'a> {
     /// Creates an Actor in the given Sandbox environment.
-    pub fn new(sandbox: &'a Sandbox) -> Self {
+    pub fn new(sandbox: &'a Sandbox) -> Result<Self> {
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
         let keyfile =
             tempfile::NamedTempFile::new_in(sandbox.tmpdir()).expect("could not create keyfile");
-        solana_sdk::signature::write_keypair_file(&keypair, &keyfile.path());
+        if solana_sdk::signature::write_keypair_file(&keypair, &keyfile.path()).is_err() {
+            return Err(Error::InputOutputError(std::io::Error::from(
+                std::io::ErrorKind::NotFound,
+            )));
+        }
         keyfile.as_file().flush().expect("could not flush keyfile");
 
-        Self {
-            sandbox: sandbox,
-            keypair: keypair,
-            pubkey: pubkey,
-            keyfile: keyfile,
-        }
+        Ok(Self {
+            sandbox,
+            keypair,
+            pubkey,
+            keyfile,
+        })
     }
 
     /// Returns the Actor's keypair.
@@ -46,7 +50,7 @@ impl<'a> Actor<'a> {
 
     /// Returns the path to a JSON file on disk containing the Actor's private
     /// key.
-    pub fn keyfile(&self) -> &std::path::Path {
+    pub fn keyfile(&self) -> &Path {
         self.keyfile.path()
     }
 
@@ -56,7 +60,7 @@ impl<'a> Actor<'a> {
 
     /// Airdrops the given number of lamports to this actor. Blocks until the
     /// airdrop is complete.
-    pub fn airdrop(&self, lamports: u64) -> Result<(), Error> {
+    pub fn airdrop(&self, lamports: u64) -> Result<()> {
         let signature = self
             .sandbox
             .client()
@@ -71,10 +75,10 @@ impl<'a> Actor<'a> {
     /// it will fall back on deploy_remote.
     pub fn try_deploy_local(
         &self,
-        program_location: &std::path::Path,
+        program_location: &Path,
         fallback_remote_location: &str,
         fallback_file_name: &str,
-    ) -> Result<Actor, Error> {
+    ) -> Result<Actor> {
         if program_location.exists() {
             self.deploy_local(program_location)
         } else {
@@ -87,8 +91,8 @@ impl<'a> Actor<'a> {
     /// `target/deploy/program.so`. Returns the Actor representing the deployed
     /// program. In particular, the returned Actor's public key is the program's
     /// public key.
-    pub fn deploy_local(&self, program_location: &std::path::Path) -> Result<Actor, Error> {
-        let actor = Actor::new(self.sandbox);
+    pub fn deploy_local(&self, program_location: &Path) -> Result<Actor> {
+        let actor = Actor::new(self.sandbox)?;
 
         let code = process::Command::new("solana")
             .args([
@@ -108,6 +112,7 @@ impl<'a> Actor<'a> {
             ])
             .spawn()?
             .wait()?;
+
         if code.success() {
             Ok(actor)
         } else {
@@ -121,10 +126,10 @@ impl<'a> Actor<'a> {
     // Then, deploys the program to solana
     // remote_location: url to raw binary (i.e. ../../raw/../something.so)
     // file_name: local file name via wget
-    pub fn deploy_remote(&self, remote_location: &str, file_name: &str) -> Result<Actor, Error> {
-        let actor = Actor::new(self.sandbox);
+    pub fn deploy_remote(&self, remote_location: &str, file_name: &str) -> Result<Actor> {
+        let actor = Actor::new(self.sandbox)?;
 
-        let _get = process::Command::new("wget")
+        let _ = process::Command::new("wget")
             .args(["-O", file_name, remote_location])
             .spawn()?
             .wait()?;
@@ -134,9 +139,9 @@ impl<'a> Actor<'a> {
                 "program",
                 "deploy",
                 "--keypair",
-                &self.keyfile().to_str().expect("could not specify keyfile"),
+                self.keyfile().to_str().expect("could not specify keyfile"),
                 "--program-id",
-                &actor.keyfile().to_str().expect("could not specify keyfile"),
+                actor.keyfile().to_str().expect("could not specify keyfile"),
                 "--commitment",
                 "confirmed",
                 "--url",
@@ -145,6 +150,7 @@ impl<'a> Actor<'a> {
             ])
             .spawn()?
             .wait()?;
+
         if code.success() {
             Ok(actor)
         } else {
@@ -161,7 +167,7 @@ impl<'a> Actor<'a> {
         target: &Pubkey,
         target_bytes: usize,
         target_owner: &Pubkey,
-    ) -> Result<Instruction, Error> {
+    ) -> Result<Instruction> {
         Ok(solana_sdk::system_instruction::create_account(
             self.pubkey(),
             target,
@@ -171,5 +177,10 @@ impl<'a> Actor<'a> {
             target_bytes as u64,
             target_owner,
         ))
+    }
+
+    /// Get account info
+    pub fn get_account_info(&self) -> Result<Account> {
+        Ok(self.sandbox.client().get_account(&self.pubkey)?)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,3 +5,5 @@ pub enum Error {
     InputOutputError(std::io::Error),
     SerumDexError(serum_dex::error::DexError),
 }
+
+pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
- Added helper functions for creating & sending transactions
- Introduced custom `Result` type & changed Actor's new function to return `Result<Self>`
- Added `consume_events_loop` (previously `crank_market`) to market structure, as well as `settle_funds`
- Got rid of outdated tests that contained personal directories